### PR TITLE
composer 安装时缺少依赖报错， 引入这个依赖之后不再报错

### DIFF
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -21,6 +21,7 @@
   "require": {
     "php": ">=7.3.0",
     "yiisoft/yii2": "~2.0.45",
+    "yidas/yii2-bower-asset": "2.0.13",
     "yiisoft/yii2-bootstrap5": "~2.0.2",
     "yiisoft/yii2-symfonymailer": "~2.0.3",
     "sizeg/yii2-jwt": "^2.0",


### PR DESCRIPTION
相关参考资料：https://packagist.org/packages/yidas/yii2-bower-asset